### PR TITLE
Support matching on host

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The Dispatcher runs as an application in which the `Dispatcher` module is overri
     1. [Basic forwarding](#Basic-forwarding)
     2. [Forwarding paths](#Forwarding-paths)
     3. [Matching on verb](#Matching-on-verb)
-    3. [Matching Accept headers](#Matching-Accept-headers)
+    4. [Matching on host](#Matching-on-host)
+    5. [Matching Accept headers](#Matching-Accept-headers)
 4. [Fallback routes and 404 pages](#Fallback-routes-and-404-pages)
 5. [Manipulating responses](#Manipulating-responses)
 6. [How-to / Extra information](#Extra-information)
@@ -228,6 +229,49 @@ end
 ```
 
 In this configuration the first case that matches wins.  If the user prefers json that's what they'll get, the same for gif or jpeg.
+
+### Matching on host
+
+Dispatching may occur based on a hostname.  Both an array-format as well as a string-format are supported to match on a host.  The string-format currently supports matching only, the array format also allows extraction.
+
+In order to reply only to calls coming in for `api.redpencil.io`, you can use the rule:
+
+```elixir
+  get "/employees", %{ host: ["io", "redpencil", "api"] } do
+    ...
+  end
+```
+
+Or, for simple matches like this, you can use a simplified API like:
+
+```elixir
+  get "/employees", %{ host: "api.redpencil.io" } do
+    ...
+  end
+```
+
+This simplified syntax is internally converted into an array match.  Wildcards are supported too:
+
+```elixir
+  get "/employees", %{ host: "*.redpencil.io" } do
+    ...
+  end
+```
+
+This wildcard will match `redpencil.io`, `api.redpencil.io`, `dev.api.redpencil.io`, etc.
+
+If you need to access a part of the API, revert back to the array syntax and define a variable:
+
+```elixir
+  get "/employees", %{ host: ["io", "redpencil", subdomain | subsubdomains] }
+    IO.inspect( subdomain, "First subdomain" )
+    IO.inspect( subsubdomains, "Array of subdomains under subdomain" )
+    ...
+  end
+```
+
+This specific implementation does require at least one subdomain and it will thus not match `redpencil.io`.
+
 
 ### Fallback routes and 404 pages
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ The Dispatcher runs as an application in which the `Dispatcher` module is overri
     1. [Host an EmberJS app](#Host-an-EmberJS-app)
     2. [External API CORS headers](#External-API-CORS-headers)
     3. [Provide 404 pages](#Provide-404-pages)
-    4. [Architecture](#Architecture)
-        1. [forwarding connections with plug_mint_proxy](#Forwarding-Connections)
-        2. [Wiring with Plug](#Wiring-with-Plug)
-        3. [Header manipulation](#Header-manipulation)
-        4. [Matcher](#Matcher)
+7. [Architecture](#Architecture)
+    1. [forwarding connections with plug_mint_proxy](#Forwarding-Connections)
+    2. [Wiring with Plug](#Wiring-with-Plug)
+    3. [Header manipulation](#Header-manipulation)
+    4. [Matcher](#Matcher)
 
 ### Configuration
 
@@ -424,20 +424,20 @@ defmodule Dispatcher do
 end
 ```
 
-### Architecture
+## Architecture
 
 The Dispatcher offers support for forwarding connections and for dispatching connections.
 
-#### Forwarding Connections
+### Forwarding Connections
 
 Forwarding connections is built on top of `plug_mint_proxy` which uses the Mint library for efficient creation of requests.  Request accepting is based on Cowboy 2 which allows for http/2 support.
 
-#### Wiring with Plug
+### Wiring with Plug
 [Plug]((https://github.com/elixir-plug/plug)) expects call to be matched using its own matcher and dispatcher.
 This library provides some extra support.  
 Although tying this in within Plug might be simple, the request is dispatched to our own matcher in [plug_router_dispatcher.ex](./lib/plug_router_dispatcher.ex).
 
-#### Header manipulation
+### Header manipulation
 
 The dispatcher knows about certain header manipulations to smoothen out configuration.  These are configured using `plug_mint_proxy`'s manipulators as seen in [the Proxy module](./lib/proxy.ex)
 
@@ -445,7 +445,7 @@ The dispatcher knows about certain header manipulations to smoothen out configur
   - [Manipulators.RemoveAcceptEncodingHeader](./lib/manipulators/remove_accept_encoding_header.ex): Removes the `accept_encoding` header from the request as encryption is handled by the identifier and should not be hanlded by backend services.
   - [Manipulators.AddVaryHeader](./lib/add_vary_header.ex): Adds the `vary` header with value `"accept, cookie"` so both of these are taken into account during incidental caching in between links or the user's browser.
 
-#### Matcher
+### Matcher
 
 [The Matcher module](./lib/matcher.ex) contains the bulk of the logic in this component.  It parses the request Accept header and parses the accept types inside of it.  It also parses the supplied accept types and searches for an optimal solution to dispatch to.
 

--- a/lib/matcher.ex
+++ b/lib/matcher.ex
@@ -80,7 +80,7 @@ defmodule Matcher do
   defmacro match_method(call, path, options, do: block) do
     # Throw warning when strange conditions occur
     unless String.starts_with?(path, "/") do
-      IO.puts "WARNING: invalid path: #{path} does not start with a `/`"
+      IO.puts("WARNING: invalid path: #{path} does not start with a `/`")
     end
 
     # Implementation
@@ -285,8 +285,9 @@ defmodule Matcher do
             functor.(acc, {received_type, received_subtype}, media_range_tuple)
         end)
       end)
+
       # |> IO.inspect(label: "Used accept maps")
-     end)
+    end)
   end
 
   defp sort_and_group_accept_headers(accept) do

--- a/lib/matcher.ex
+++ b/lib/matcher.ex
@@ -159,40 +159,6 @@ defmodule Matcher do
     end
   end
 
-  # # Accept headers
-  # defmacro accept(spec, key, value \\ true) do
-  #   spec_arr =
-  #     spec
-  #     |> String.split("/")
-  #     |> Enum.map(fn
-  #       "*" -> Macro.var(:_, nil)
-  #       str -> String.to_charlist(str)
-  #     end)
-
-  #   [type, subtype] = spec_arr
-  #   spec_tuple = {type, subtype}
-
-  #   spec_any_subtype = { subtype, "*" }
-  #   spec_any = { "*", "*" }
-
-  #   quote do
-  #     defp transform_accept_header(accept_hash, unquote(spec_tuple), _media_range) do
-  #       accept_hash
-  #       |> Map.put(unquote(key), unquote(value))
-  #     end
-
-  #     defp transform_accept_header(accept_hash, unquote(spec_any_subtype), _media_range) do
-  #       accept_hash
-  #       |> Map.put(unquote(key), unquote(value))
-  #     end
-
-  #     defp transform_accept_header(accept_hash, unquote(spec_any), _media_range) do
-  #       accept_hash
-  #       |> Map.put(unquote(key), unquote(value))
-  #     end
-  #   end
-  # end
-
   defmacro define_accept_types(received_accept_types) do
     quote do
       def accept_types do
@@ -200,14 +166,6 @@ defmodule Matcher do
       end
     end
   end
-
-  # defmacro last_accept do
-  #   quote do
-  #     defp transform_accept_header(accept_hash, _, _media_range) do
-  #       accept_hash
-  #     end
-  #   end
-  # end
 
   # Call dispatching
   def dispatch_call(conn, accept_types, call_handler) do


### PR DESCRIPTION
Support matching on host.  The README.md has a section explaining the currently supported interface.  This feature removes the requirement to set a last_match.

## Implementation

The implementation now first scans for all routes in the file.  It collects all of them and then bundles them together in one block.  We do this because we want to expand deep in the supplied arguments.

The downside of this approach is that quite a bit of code has been added.  The upsides are:
- no requirement to add last_match as we can implement this ourselves
- match statements can be written at multiple places in the file

## Things to consider

It is clear from the documentation that the `host` key can be used for two approaches.  One approach is a fairly simple array-match, the second is a string which is expanded into an array match.

Is it okay to use the same key when syntactic sugar is added?

Based on current thoughts it seems safe to allow for this form of syntactic sugar with the same key.  We would have a similar approach when adding a "dumber" array-match statement when matching the path.  If you can add it inline there, then it would also make sense to add it inline here.  Further, there is always going to be pre-processing for this case, so the implementation will not become significantly simpler if two approaches are used.

Still, would it be more obvious for end-users to have two keys for both this purpose, or is it easier to grok a single key?